### PR TITLE
Set up Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/test/site/
+!/test/site/.gitkeep

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,8 @@
+name: classicpress-migration-plugin
+recipe: wordpress
+config:
+  webroot: test/site/
+  php: '7.0'
+tooling:
+  bash:
+    service: appserver

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+sudo: required
+dist: trusty
+
+# this section doesn't matter because services are managed using lando
+language: php
+php:
+  - '7.0'
+
+env:
+  - WP_VERSION=4.9.7 PHP_VERSION=7.0
+
+# https://docs.devwithlando.io/tutorials/lando-and-ci.html#lando-ify-your-travisyml
+
+services:
+  - docker
+
+before_install:
+  - sudo apt-get -y update
+  - sudo apt-get -y install cgroup-bin curl
+  - curl -L -o /tmp/lando-latest.deb https://github.com/lando/lando/releases/download/v3.0.0-rc.1/lando-v3.0.0-rc.1.deb
+  - sudo dpkg -i /tmp/lando-latest.deb
+  - lando version
+  - ./test/lando-setup.sh
+
+script:
+  - true

--- a/test/install-wp-cli.sh
+++ b/test/install-wp-cli.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mkdir -p /var/www/.composer/vendor/bin
+wget https://github.com/wp-cli/wp-cli/releases/download/v2.0.1/wp-cli-2.0.1.phar -O /var/www/.composer/vendor/bin/wp
+chmod +x /var/www/.composer/vendor/bin/wp
+wp --version

--- a/test/lando-setup.sh
+++ b/test/lando-setup.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# exit on error
+set -e
+
+WP_VERSION="${WP_VERSION:-4.9.7}"
+PHP_VERSION="${PHP_VERSION:-7.0}"
+
+cd "$(dirname "$0")"
+cd ..
+
+# Hack - awaiting https://github.com/lando/lando/pull/750
+perl -pi -we "s/^  php: .*/  php: '$PHP_VERSION'/" .lando.yml
+
+lando start -v
+lando wp --version || lando bash test/install-wp-cli.sh
+rm -rf test/site/[a-z]*
+lando wp core download \
+    --path=test/site/ \
+    --version=$WP_VERSION
+
+lando wp config create \
+    --path=test/site/ \
+    --dbname=wordpress \
+    --dbuser=wordpress \
+    --dbpass=wordpress \
+    --dbhost=database
+
+lando wp config set \
+    --path=test/site/ \
+    --type=constant \
+    --raw \
+    WP_AUTO_UPDATE_CORE false
+
+lando wp config set \
+    --path=test/site/ \
+    --type=constant \
+    --raw \
+    WP_DEBUG true
+
+wp_url="$(lando info | grep -A2 '"urls": \[$' | tail -n 1 | cut -d'"' -f2)"
+lando wp core install \
+    --path=test/site/ \
+    --url="$wp_url" \
+    '--title="My Test Site"' \
+    --admin_user="admin" \
+    --admin_password="admin" \
+    --admin_email="admin@example.com" \
+    --skip-email
+
+echo "Testing site URL: $wp_url"
+
+mkdir test/site/wp-content/plugins/switch-to-classicpress
+ln -vs \
+    ../../../../../switch-to-classicpress.php \
+    test/site/wp-content/plugins/switch-to-classicpress/
+ln -vs \
+    ../../../../../lib/ \
+    test/site/wp-content/plugins/switch-to-classicpress/
+lando wp plugin activate \
+    --path=test/site/ \
+    switch-to-classicpress

--- a/test/lando-tail-logs.sh
+++ b/test/lando-tail-logs.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Watch the webserver's `error_log` file inside the lando container, and clean
+# up a bunch of noise in the output.
+
+lando logs appserver_1 -f | perl -nwe '
+	# no buffering
+	select(STDOUT); $| = 1;
+
+	# add colors, but only if stdout is a terminal
+	my $acc_begin = "";
+	my $err_begin = "";
+	my $end = "";
+	-t 1 and $acc_begin = "\e[0;32m"; # green
+	-t 1 and $err_begin = "\e[1;35m"; # purple
+	-t 1 and $end = "\e[0m"; # reset
+
+	# get rid of appserver_1 prefix + ANSI codes
+	s/^.{0,8}appserver_1\s+\|.{0,8}\s+//;
+
+	if (/\[:error\]/) {
+		# clean up error log entry
+		# get rid of unneeded markers
+		s/\[:error\] \[pid \d+\] \[client [^]]+\] //;
+
+		# keep and maybe colorize time, remove date and microseconds
+		s/^\[... ... \d\d /${err_begin}E /;
+		s/\d\d\d 20\d\d\]/${end}/;
+
+		# remove "referer"
+		s/, referer: h\S+$//;
+
+		print;
+
+	} elsif (/^[\d.]+ - -/) {
+		# clean up access log entry
+		s/^/${acc_begin}A /;
+		s/ - - \[.*20\d\d:/ /;
+		s/ [\d+-]+\]/${end}/;
+
+		# TODO: ignored (not printed)
+	}
+'


### PR DESCRIPTION
We need fairly extensive automated QA for this plugin, covering multiple PHP and WP versions, so it's best to go ahead and set that up as soon as possible.

### What's done

So far, I'm using [`lando`](https://github.com/lando/lando) to spin up a WP site and install the plugin.  This automated setup has made it much easier to develop the plugin locally, and the PHP and WP versions are configurable.

### What's still left to do

First, make sure this setup works on Travis.

Then, I'll use [`puppeteer`](https://github.com/GoogleChrome/puppeteer) to simulate logging in to the site and performing the upgrade, and make sure the results are as expected.

Finally we can build out a test matrix for various combinations of versions, features, etc.

It might also be a good idea to add a test for a "normal" WP upgrade and make sure the plugin doesn't interfere.