### PR TITLE
Prevent multiple clicks on the Migrate button

### DIFF
--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -506,7 +506,12 @@ function classicpress_show_migration_controls() {
 		name="upgrade"
 	>
 		<?php wp_nonce_field( 'upgrade-core' ); ?>
-		<button class="button button-primary button-hero" type="submit" name="upgrade">
+		<input type="hidden" name="upgrade" value="yes" />
+		<button
+			class="button button-primary button-hero"
+			type="submit"
+			onclick="javascript:this.disabled = true;"
+		>
 <?php
 	if ( is_multisite() ) {
 		_e(


### PR DESCRIPTION
This PR aims to prevent multiple clicks on the Migrate button, which is a potential cause for this error:

> Another update is currently in progress.

In order to continue sending the `upgrade` value from the form, which is [required](https://github.com/ClassicPress/ClassicPress/blob/ced817fd49e84f0efa646591e1faa941ca5a83bd/src/wp-admin/update-core.php#L695) for the upgrade process to trigger, we need to add a new `<input type="hidden">` element because [disabled elements are not submitted as part of a form](https://stackoverflow.com/questions/1355728/values-of-disabled-inputs-will-not-be-submitted).

cc: @ginsterbusch