### PR TITLE
Enable migrating from ClassicPress to anything

### DIFF
--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -664,19 +664,6 @@ function classicpress_show_advanced_migration_controls() {
 					<input type="text" id="cp-build-url" name="_build_url" value="">
 				</td>
 			</tr>
-			<tr>
-				<th scope="row">
-					<label for="cp-build-version">
-						<?php esc_html_e(
-							'Version:',
-							'switch-to-classicpress'
-						); ?>
-					</label>
-				</th>
-				<td>
-					<input type="text" id="cp-build-version" name="version" value="">
-				</td>
-			</tr>
 		</table>
 		<?php wp_nonce_field( 'upgrade-core' ); ?>
 		<button class="button button-primary button-hero" type="submit" name="upgrade">

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -94,6 +94,9 @@ table#cp-preflight-checks {
 #cp-migration-form {
 	margin: 2em 0 3em;
 }
+#cp-advanced-migration-form {
+	margin: 3em 0 4em;
+}
 </style>
 <?php
 }
@@ -242,6 +245,7 @@ function classicpress_check_can_migrate() {
 			</p>
 		</div>
 <?php
+		classicpress_show_advanced_migration_controls();
 		return false;
 	}
 
@@ -557,7 +561,7 @@ function classicpress_show_migration_controls() {
 	<form
 		id="cp-migration-form"
 		method="post"
-		action="update-core.php?action=do-core-upgrade&amp;migrate=classicpress"
+		action="update-core.php?action=do-core-upgrade&amp;_migrate=classicpress"
 		name="upgrade"
 	>
 		<?php wp_nonce_field( 'upgrade-core' ); ?>
@@ -619,5 +623,68 @@ function classicpress_show_migration_blocked_info() {
 			'switch-to-classicpress'
 		); ?>
 	</p>
+<?php
+}
+
+/**
+ * Show the controls and information needed to migrate to any version of
+ * WordPress or ClassicPress.
+ *
+ * NOTE: BE VERY CAREFUL WITH THIS, IT HAS JUST BARELY BEEN TESTED!
+ * Otherwise you *will* end up with a broken site!
+ *
+ * @since 0.6.0
+ */
+function classicpress_show_advanced_migration_controls() {
+?>
+	<form
+		id="cp-advanced-migration-form"
+		class="hidden"
+		method="post"
+		action="update-core.php?action=do-core-upgrade&amp;_migrate=_custom"
+		name="upgrade"
+	>
+		<h2>
+			<?php esc_html_e(
+				'Switch to any version of ClassicPress or WordPress',
+				'switch-to-classicpress'
+			); ?>
+		</h2>
+		<table class="form-table">
+			<tr>
+				<th scope="row">
+					<label for="cp-build-url">
+						<?php esc_html_e(
+							'Build URL:',
+							'switch-to-classicpress'
+						); ?>
+					</label>
+				</th>
+				<td>
+					<input type="text" id="cp-build-url" name="_build_url" value="">
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="cp-build-version">
+						<?php esc_html_e(
+							'Version:',
+							'switch-to-classicpress'
+						); ?>
+					</label>
+				</th>
+				<td>
+					<input type="text" id="cp-build-version" name="version" value="">
+				</td>
+			</tr>
+		</table>
+		<?php wp_nonce_field( 'upgrade-core' ); ?>
+		<button class="button button-primary button-hero" type="submit" name="upgrade">
+			<?php esc_html_e(
+				'Do the custom migration now!',
+				'migrate-to-classicpress'
+			); ?>
+		</button>
+	</form>
 <?php
 }

--- a/lib/update.php
+++ b/lib/update.php
@@ -200,10 +200,15 @@ function classicpress_override_upgrade_page() {
 	}
 
 	if ( $_GET['_migrate'] === '_custom' ) {
-		if ( empty( $_POST['version'] ) || empty( $_POST['_build_url'] ) ) {
+		if ( empty( $_POST['_build_url'] ) ) {
 			// The request is no good.
 			return;
 		}
+
+		// Set the (fake) version string used in the custom migration.  This is
+		// used in the `find_core_update()` function - it only needs to match
+		// the version returned when we override the update API.
+		$_POST['version'] = '_custom_migration';
 
 		// Add our hooks into the upgrade process.
 		add_filter( 'pre_http_request', 'classicpress_override_wp_update_api', 10, 3 );


### PR DESCRIPTION
Further steps towards issue #27 (restore the previous version of WordPress).

This is **pre-alpha** functionality - do not run it on sites you care about!  Accordingly, the form has `class="hidden"` which you must remove yourself in order to test this.

![cp-custom-migration](https://user-images.githubusercontent.com/227022/51808330-78c6a580-2260-11e9-80e0-14164b5812f8.gif)

To show the form:

- Ensure you are running ClassicPress
- Visit the Switch to ClassicPress plugin page
- Paste the following JavaScript snippet in the developer console and run it:

```js
jQuery('#cp-advanced-migration-form').removeClass('hidden')
```

To use it, enter a valid build URL ~and version~ (for example `https://wordpress.org/wordpress-4.9.9.zip` ~and `4.9.9`~).

~**Important limitation:** this code (and the migration plugin in general) cannot migrate to all official release builds of ClassicPress, only builds that are specifically made for the migration plugin!  More info about this limitation [here](https://github.com/ClassicPress/ClassicPress-Migration-Plugin/issues/39#issue-380993876).~ This limitation has been addressed in the ClassicPress core code, to the extent possible.