### PR TITLE
Add note to README.md about compatible WP versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,7 @@ ensure any known conflicting plugins are **deactivated** (see list
 
 ## What version of WordPress does the plugin work with?
 
-As of version 1.2.0, the plugin has been confirmed as working on the following WordPress versions:
-**Minimum: `4.9.x`**
-**Maximum: `5.5.3`**
-If you experience any issues, please let us know in [our support forum](https://forums.classicpress.net/c/support/migration-plugin).
+You can always see the latest supported version by going to [Get ClassicPress](https://www.classicpress.net/get-classicpress/#switch-to-classicpress).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ backup before switching a live production site to ClassicPress. Please also
 ensure any known conflicting plugins are **deactivated** (see list
 [here](https://docs.classicpress.net/installing-classicpress/#plugin-conflicts)).
 
+## What version of WordPress does the plugin work with?
+
+As of version 1.2.0, the plugin has been confirmed as working on the following WordPress versions:
+**Minimum: `4.9.x`**
+**Maximum: `5.5.3`**
+If you experience any issues, please let us know in [our support forum](https://forums.classicpress.net/c/support/migration-plugin).
+
 ## Installation
 
 To **install a fresh version of ClassicPress on a new site**, you do not need


### PR DESCRIPTION
At present, it is not immediately clear which versions of WordPress are supported by the migration plugin.

This small update to `README.md` makes it much easier to find that information.

As things stand, the WP version will need to be updated manually on each new release of the plugin.