### PR TITLE
Add theme header comparison check to compatibility logic

### DIFF
--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -453,8 +453,7 @@ function classicpress_check_can_migrate() {
 	$theme = wp_get_theme();
 	if ( isset( $parameters['themes'] ) &&
 		in_array( $theme->stylesheet, (array) $parameters['themes'] ) ||
-		( is_child_theme() && in_array( $theme->parent()->stylesheet, (array) $parameters['themes'] ) ) ||
-		version_compare( $theme->get( 'RequiresWP' ), '5.0' ) >= 0
+		( is_child_theme() && in_array( $theme->parent()->stylesheet, (array) $parameters['themes'] ) )
 	) {
 		$preflight_checks['theme'] = false;
 		echo "<tr>\n<td>$icon_preflight_fail</td>\n<td>\n";
@@ -463,6 +462,27 @@ function classicpress_check_can_migrate() {
 			'It looks like you are using the <strong>%1$s</strong> theme. Unfortunately it is incompatible with ClassicPress.',
 			'switch-to-classicpress'
 		), $theme->name );
+		echo "<br>\n";
+		_e(
+			'Consider switching to a different theme, perhaps an older core theme, and try again.',
+			'switch-to-classicpress'
+		);
+	} elseif ( empty ( $theme->get( 'RequiresWP' ) ) ) {
+		$preflight_checks['theme'] = true;
+		echo "<tr>\n<td>$icon_preflight_warn</td>\n<td>\n";
+		printf( __(
+			/* translators: active theme name */
+			'It looks like you are using the <strong>%1$s</strong> theme. We cannot be sure it is compatible with ClassicPress because it is not declaring a minimum required version of WordPress.',
+			'switch-to-classicpress'
+		), $theme->name );
+	} elseif ( version_compare( $theme->get( 'RequiresWP' ), '5.0' ) >= 0 ) {
+		$preflight_checks['theme'] = false;
+		echo "<tr>\n<td>$icon_preflight_fail</td>\n<td>\n";
+		printf( __(
+			/* translators: active theme name */
+			'It looks like you are using the <strong>%1$s</strong> theme. Unfortunately it seems it requires WordPress %2$s or above and it is therefore incompatible with ClassicPress.',
+			'switch-to-classicpress'
+		), $theme->name, $theme->get( 'RequiresWP' ) );
 		echo "<br>\n";
 		_e(
 			'Consider switching to a different theme, perhaps an older core theme, and try again.',

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -460,7 +460,7 @@ function classicpress_check_can_migrate() {
 		echo "<tr>\n<td>$icon_preflight_fail</td>\n<td>\n";
 		printf( __(
 			/* translators: active theme name */
-			'It looks like you are using the <strong>%1$s</strong> theme. Unfortuantely it is incompatible with ClassicPress.',
+			'It looks like you are using the <strong>%1$s</strong> theme. Unfortunately it is incompatible with ClassicPress.',
 			'switch-to-classicpress'
 		), $theme->name );
 		echo "<br>\n";

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -453,7 +453,8 @@ function classicpress_check_can_migrate() {
 	$theme = wp_get_theme();
 	if ( isset( $parameters['themes'] ) &&
 		in_array( $theme->stylesheet, (array) $parameters['themes'] ) ||
-		( is_child_theme() && in_array( $theme->parent()->stylesheet, (array) $parameters['themes'] ) )
+		( is_child_theme() && in_array( $theme->parent()->stylesheet, (array) $parameters['themes'] ) ) ||
+		version_compare( $theme->get( 'RequiresWP' ), '5.0' ) >= 0
 	) {
 		$preflight_checks['theme'] = false;
 		echo "<tr>\n<td>$icon_preflight_fail</td>\n<td>\n";

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -480,7 +480,7 @@ function classicpress_check_can_migrate() {
 		echo "<tr>\n<td>$icon_preflight_fail</td>\n<td>\n";
 		printf( __(
 			/* translators: active theme name */
-			'It looks like you are using the <strong>%1$s</strong> theme. Unfortunately it seems it requires WordPress %2$s or above and it is therefore incompatible with ClassicPress.',
+			'It looks like you are using the <strong>%1$s</strong> theme. Unfortunately it seems it requires WordPress %2$s or above and it may therefore be incompatible with ClassicPress.',
 			'switch-to-classicpress'
 		), $theme->name, $theme->get( 'RequiresWP' ) );
 		echo "<br>\n";


### PR DESCRIPTION
This PR adds a compatibility check to Theme Headers to check the value is not 5.0 or above.

It may need more work to assess what happens if that header is not present.