### PR TITLE
Add plugin header checking

### DIFF
--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -485,7 +485,7 @@ function classicpress_check_can_migrate() {
 
 	// Start by checking if plugins have declared they require WordPress 5.0 or higher
 	foreach ( $plugins as $plugin ) {
-		$plugin_data = get_file_data( WP_CONTENT_DIR . '/plugins/' . $plugin, $plugin_headers );
+		$plugin_data = get_file_data( WP_PLUGIN_DIR . '/' . $plugin, $plugin_headers );
 		if ( version_compare( $plugin_data['RequiresWP'], '5.0' ) >= 0 ) {
 			$declared_incompatible_plugins[ $plugin ] = $plugin_data['Name'];
 		}

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -529,8 +529,8 @@ function classicpress_check_can_migrate() {
 		$conflicting_plugins = array_intersect( $parameters['plugins'], $plugins );
 		$conflicting_plugin_names = array();
 		foreach( $conflicting_plugins as $conflicting_plugin ) {
-			$conflicting_plugin_data[] = get_plugin_data( WP_CONTENT_DIR . '/plugins/' . $conflicting_plugin );
-			$conflicting_plugin_names[] = $conflicting_plugin_data[0]['Name'];
+			$conflicting_plugin_data = get_plugin_data( WP_CONTENT_DIR . '/plugins/' . $conflicting_plugin );
+			$conflicting_plugin_names[] = $conflicting_plugin_data['Name'];
 		}
 
 		if ( ! empty( $declared_incompatible_plugins ) ) {

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -482,12 +482,30 @@ function classicpress_check_can_migrate() {
 	$plugins = get_option( 'active_plugins' );
 	$plugin_headers = array( 'Name' => 'Plugin Name', 'RequiresWP'  => 'Requires at least' );
 	$declared_incompatible_plugins = array();
+	$undeclared_compatibility_plugins = array();
 
 	// Start by checking if plugins have declared they require WordPress 5.0 or higher
 	foreach ( $plugins as $plugin ) {
 		$plugin_data = get_file_data( WP_PLUGIN_DIR . '/' . $plugin, $plugin_headers );
 		if ( version_compare( $plugin_data['RequiresWP'], '5.0' ) >= 0 ) {
 			$declared_incompatible_plugins[ $plugin ] = $plugin_data['Name'];
+		} else {
+			$plugin_files = get_plugin_files( $plugin );
+			$readmes = array_filter( $plugin_files, function( $el ) {
+				return ( stripos( $el, 'readme') !== false );
+			} );
+			foreach( $readmes as $readme ) {
+				if ( empty( $readme ) ) {
+					continue;
+				}
+				$readme_data = get_file_data( WP_PLUGIN_DIR . '/' . $readme, $plugin_headers );
+				if ( version_compare( $readme_data['RequiresWP'], '5.0' ) >= 0 ) {
+					$declared_incompatible_plugins[ $plugin ] = $plugin_data['Name'];
+				}
+			}
+		}
+		if ( empty( $plugin_data['RequiresWP'] ) && ( empty( $readmes) || empty( $readme_data['RequiresWP'] ) ) ) {
+			$undeclared_compatibility_plugins[ $plugin ] = $plugin_data['Name'];
 		}
 	}
 
@@ -524,7 +542,7 @@ function classicpress_check_can_migrate() {
 		echo "<br>\n";
 		/* translators: List of conflicting plugin names */
 		printf( __(
-			'<strong>%s<sttong>',
+			'<strong>%s<strong>',
 			'switch-to-classicpress'
 		), implode( ', ', $conflicting_plugin_names ) );
 	} else {
@@ -534,6 +552,27 @@ function classicpress_check_can_migrate() {
 			'We are not aware that any of your active plugins are incompatible with ClassicPress.',
 			'switch-to-classicpress'
 		);
+	}
+	echo "</td></tr>\n";
+
+	if ( ! empty( $undeclared_compatibility_plugins ) ) {
+		echo "<tr>\n<td>$icon_preflight_warn</td>\n<td>\n";
+		_e(
+			'We have detected one or more plugins that fail to declare a minimum compatible WordPress version. They may prevent or impact on migrating your site to ClassicPress.',
+			'switch-to-classicpress'
+		);
+		echo "<br>\n";
+		 _e(
+			'We would recommned deactivating the following plugins if you wish to continue migrating your site to ClassicPress:',
+			'switch-to-classicpress'
+		);
+		echo "<br>\n";
+		/* translators: List of conflicting plugin names */
+		printf( __(
+			'<strong>%s<strong>',
+			'switch-to-classicpress'
+		), implode( ', ', $undeclared_compatibility_plugins ) );
+		echo "</td></tr>\n";
 	}
 
 	// Check: Supported PHP version

--- a/switch-to-classicpress.php
+++ b/switch-to-classicpress.php
@@ -10,7 +10,7 @@
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.txt
  * Domain Path:       /languages
  * Text Domain:       switch-to-classicpress
- *
+ * Requires at least: 4.9
  * @package ClassicPress
  */
 


### PR DESCRIPTION
This patch will scan plugin headers for plugins declaring a requirement for WordPress 5.0 and above.

If adopted, this fixes #77