### PR TITLE
Bump Version number

### DIFF
--- a/switch-to-classicpress.php
+++ b/switch-to-classicpress.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Switch to ClassicPress
  * Plugin URI:        https://github.com/ClassicPress/ClassicPress-Migration-Plugin
  * Description:       Switch your WordPress installation to ClassicPress.
- * Version:           1.3.1
+ * Version:           1.4.1
  * Author:            ClassicPress
  * Author URI:        https://www.classicpress.net
  * License:           GPLv2 or later


### PR DESCRIPTION
Version numbers should be bumped when updating the plugin.
Note, now due to the semver it cannot be 1.4.0 but must be 1.4.1