### PR TITLE
Implement PHP version checking based on migration API endpoint

### DIFF
--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -609,7 +609,7 @@ function classicpress_check_can_migrate() {
 	// Check: Supported PHP version
 	if ( isset( $parameters['php'] ) &&
 		version_compare( PHP_VERSION, $parameters['php']['min'], 'lt' ) ||
-		version_compare( PHP_VERSION, $parameters['php']['unsupported'], 'ge' )
+		version_compare( PHP_VERSION, $parameters['php']['max'], 'gt' )
 	) {
 		$preflight_checks['php_version'] = false;
 		echo "<tr>\n<td>$icon_preflight_fail</td>\n<td>\n";
@@ -622,7 +622,7 @@ function classicpress_check_can_migrate() {
 		/* translators: minimum supported PHP version */
 		'ClassicPress supports PHP versions <strong>%1$s</strong> to <strong>%2$s</strong>.',
 		'switch-to-classicpress'
-	), $parameters['php']['min'], $parameters['php']['max'] );
+	), $parameters['php']['min'], $parameters['php']['max_display'] );
 	echo "<br>\n";
 	printf( __(
 		/* translators: current PHP version */

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -619,7 +619,7 @@ function classicpress_check_can_migrate() {
 	}
 	echo "<p>\n";
 	printf( __(
-		/* translators: minimum supported PHP version */
+		/* translators: minimum supported PHP version, maximum supported PHP version */
 		'ClassicPress supports PHP versions <strong>%1$s</strong> to <strong>%2$s</strong>.',
 		'switch-to-classicpress'
 	), $parameters['php']['min'], $parameters['php']['max_display'] );

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -607,9 +607,11 @@ function classicpress_check_can_migrate() {
 	}
 
 	// Check: Supported PHP version
-	if ( isset( $parameters['php'] ) &&
-		version_compare( PHP_VERSION, $parameters['php']['min'], 'lt' ) ||
-		version_compare( PHP_VERSION, $parameters['php']['max'], 'gt' )
+	if (
+		isset( $parameters['php'] ) && (
+			version_compare( PHP_VERSION, $parameters['php']['min'], 'lt' ) ||
+			version_compare( PHP_VERSION, $parameters['php']['max'], 'gt' )
+		)
 	) {
 		$preflight_checks['php_version'] = false;
 		echo "<tr>\n<td>$icon_preflight_fail</td>\n<td>\n";

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -607,8 +607,10 @@ function classicpress_check_can_migrate() {
 	}
 
 	// Check: Supported PHP version
-	$php_version_min = '5.6';
-	if ( version_compare( PHP_VERSION, $php_version_min, 'lt' ) ) {
+	if ( isset( $parameters['php'] ) &&
+		version_compare( PHP_VERSION, $parameters['php']['min'], 'lt' ) ||
+		version_compare( PHP_VERSION, $parameters['php']['unsupported'], 'ge' )
+	) {
 		$preflight_checks['php_version'] = false;
 		echo "<tr>\n<td>$icon_preflight_fail</td>\n<td>\n";
 	} else {
@@ -618,9 +620,9 @@ function classicpress_check_can_migrate() {
 	echo "<p>\n";
 	printf( __(
 		/* translators: minimum supported PHP version */
-		'ClassicPress supports PHP versions <strong>%1$s</strong> and <strong>newer</strong>.',
+		'ClassicPress supports PHP versions <strong>%1$s</strong> to <strong>%2$s</strong>.',
 		'switch-to-classicpress'
-	), $php_version_min );
+	), $parameters['php']['min'], $parameters['php']['max'] );
 	echo "<br>\n";
 	printf( __(
 		/* translators: current PHP version */

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -621,7 +621,7 @@ function classicpress_check_can_migrate() {
 	}
 	echo "<p>\n";
 	printf( __(
-		/* translators: minimum supported PHP version, maximum supported PHP version */
+		/* translators: 1: minimum supported PHP version, 2: maximum supported PHP version */
 		'ClassicPress supports PHP versions <strong>%1$s</strong> to <strong>%2$s</strong>.',
 		'switch-to-classicpress'
 	), $parameters['php']['min'], $parameters['php']['max_display'] );


### PR DESCRIPTION
See also:
https://github.com/ClassicPress/ClassicPress-APIs/pull/31

This PR alters checking of supported PHP versions to utilise data from the migration API endpoint with the aim of stopping migration on WordPress sites that are using PHP version 8.0 and higher.