### PR TITLE
Code tidy to remove some asset() checks

### DIFF
--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -451,7 +451,7 @@ function classicpress_check_can_migrate() {
 
 	// Check: Conflicting Theme
 	$theme = wp_get_theme();
-	if ( isset( $parameters['themes'] ) &&
+	if (
 		in_array( $theme->stylesheet, (array) $parameters['themes'] ) ||
 		( is_child_theme() && in_array( $theme->parent()->stylesheet, (array) $parameters['themes'] ) )
 	) {
@@ -507,7 +507,7 @@ function classicpress_check_can_migrate() {
 
 	// Start by checking if plugins have declared they require WordPress 5.0 or higher
 	foreach ( $plugins as $plugin ) {
-		if ( isset( $parameters['plugins'] ) && in_array( $plugin, $parameters['plugins'] ) ) {
+		if ( in_array( $plugin, $parameters['plugins'] ) ) {
 			continue;
 		}
 
@@ -542,7 +542,7 @@ function classicpress_check_can_migrate() {
 
 	// Compare active plugins with API response of known conflicting plugins
 	if (
-		isset( $parameters['plugins'] ) && $plugins !== array_diff( $plugins, $parameters['plugins'] ) ||
+		$plugins !== array_diff( $plugins, $parameters['plugins'] ) ||
 		! empty( $declared_incompatible_plugins )
 	) {
 		$preflight_checks['plugins'] = false;
@@ -608,10 +608,8 @@ function classicpress_check_can_migrate() {
 
 	// Check: Supported PHP version
 	if (
-		isset( $parameters['php'] ) && (
-			version_compare( PHP_VERSION, $parameters['php']['min'], 'lt' ) ||
-			version_compare( PHP_VERSION, $parameters['php']['max'], 'gt' )
-		)
+		version_compare( PHP_VERSION, $parameters['php']['min'], 'lt' ) ||
+		version_compare( PHP_VERSION, $parameters['php']['max'], 'gt' )
 	) {
 		$preflight_checks['php_version'] = false;
 		echo "<tr>\n<td>$icon_preflight_fail</td>\n<td>\n";


### PR DESCRIPTION
This has already been discussed a little elsewhere:
https://github.com/ClassicPress/ClassicPress-Migration-Plugin/pull/90

Some `asset()` checks have been added to the plugin during development to ensure local code worked while the API endpoint was still in need of amendment.

These checks are probably unnecessary in the release version of the plugin. So this patch removes individual checks for the API data for more consistency through plugin and because there is a central API response check.