### PR TITLE
Possible fix for #95

### DIFF
--- a/lib/check-core-files.php
+++ b/lib/check-core-files.php
@@ -29,8 +29,11 @@ function classicpress_check_core_files( $locale = 'en_US' ) {
 
 	$modified = array();
 	foreach ( $checksums as $file => $checksum ) {
-		// Skip plugins, themes, etc.
-		if ( 'wp-content' == substr( $file, 0, 10 ) ) {
+		// Skip sample config, plugins, themes, etc.
+		if (
+			'wp-content' == substr( $file, 0, 10 ) ||
+			'wp-config-sample.php' == substr( $file, 0, 20 )
+		) {
 			continue;
 		}
 		if (


### PR DESCRIPTION
This is a possible fix for #95, core file changes are reported if wp-config-sample.php is missing, perhaps we should not report that as an issue when migrating.