### PR TITLE
Migration Plugin Update

### DIFF
--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -292,10 +292,9 @@ if (strpos($cp_version, 'migration')) {
 			</p>
 			<p>
 				<?php echo sprintf(
-					// DELETE THIS PART?
 					/* translators: %s: URL to plugins page */
 					__(
-						'If no longer needed. you can <a href="%s">delete the plugin</a>.',
+						'If no longer needed you can <a href="%s">delete the plugin</a>.',
 						'switch-to-classicpress'
 					),
 					$delete_plugin_url

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -267,18 +267,21 @@ function classicpress_check_can_migrate() {
 		}
 ?>
 		<div class="notice notice-success">
-			<h3>
-				<?php esc_html_e(
-					"Good job, you're already running ClassicPress v".preg_replace('#[+-].*$#', '', $cp_version)."!",
-					'switch-to-classicpress'
-				); ?>
-			</h3>
 <?php
-if (str_contains($cp_version, 'migration')) { 
-	_e(
-		"<strong class='cp-emphasis'>You must visit the <a href='".$reinstall_url."'>Updates Page</a> and Press the Re-Install Now button to complete the switch to ClassicPress!</strong>",
-		'switch-to-classicpress'
-	);
+if (strpos($cp_version, 'migration')) {
+			_e(
+				"<h3>You're almost done switching to ClassicPress v".preg_replace('#[+-].*$#', '', $cp_version)."!</h3>",
+				'switch-to-classicpress'
+			);
+			_e(
+				"<strong class='cp-emphasis'>You must visit the <a href='".$reinstall_url."'>Updates Page</a> and Press the Re-Install Now button to complete the migration process!</strong>",
+				'switch-to-classicpress'
+			);
+} else {
+			_e(
+				"<h3>Good job, you're running ClassicPress v".preg_replace('#[+-].*$#', '', $cp_version)."!</h3>",
+				'switch-to-classicpress'
+			);
 }
 ?>
 			<p>
@@ -617,7 +620,7 @@ if (str_contains($cp_version, 'migration')) {
 		);
 		echo "<br>\n";
 		 _e(
-			'We suggest (temporarily) deactivating the following plugins to safetly migrate your site to ClassicPress:',
+			'We suggest (temporarily) deactivating the following plugins would be the safest way to migrate your site to ClassicPress:',
 			'switch-to-classicpress'
 		);
 		echo "<br>\n";
@@ -926,14 +929,18 @@ function classicpress_show_advanced_migration_controls( $ok = true ) {
 	global $wp_version;
 	if (!$is_wp) {
 		global $cp_version;
-		$my_cp = preg_replace('#[+-].*$#', '', $cp_version);
+		if (strpos($cp_version, 'migration')) {
+			$my_cp = "0.0.0";
+		} else {
+			$my_cp = preg_replace('#[+-].*$#', '', $cp_version);
+		}
 		// Build Proper URL here (ClassicPress can use Release)
 		$cp_cv_build = getReleaseFromCPVersion($cp_cv);
 		$cp_p2_build = getReleaseFromCPVersion($v2_previous);
 		$cp_v1_build = getReleaseFromCPVersion($cp_v1);
 		$cp_p1_build = getReleaseFromCPVersion($v1_previous);
 	} else {
-		$my_cp = "";
+		$my_cp = "0.0.0";
 		// Build Proper URL here (WordPress must use Migration)
 		$cp_cv_build = $cp_api_parameters['links']['ClassicPress v2'];
 		$cp_p2_build = $v2_prev_url;
@@ -1036,28 +1043,37 @@ function classicpress_show_advanced_migration_controls( $ok = true ) {
 					<optgroup label="ClassicPress Builds">
 <?php if ($my_cp != $cp_cv) { ?>
 						<option value="<?php echo $cp_cv_build; ?>">ClassicPress v<?php echo $cp_cv; ?></option>
-<?php }
-if ($my_cp != $v2_previous && substr($v2_previous, 0, 1) == substr($cp_cv, 0, 1)) { ?>
+<?php 
+	}
+	if ($my_cp != $v2_previous && substr($v2_previous, 0, 1) == substr($cp_cv, 0, 1)) { 
+?>
     					<option value="<?php echo $cp_p2_build; ?>">ClassicPress v<?php echo $v2_previous; ?></option>
-<?php }
-if ($my_cp != $cp_v1) { ?>
+<?php 
+	}
+	if ($my_cp != $cp_v1) { 
+?>
     					<option value="<?php echo $cp_v1_build; ?>">ClassicPress v<?php echo $cp_v1; ?></option>
-<?php }
-if ($my_cp != $v1_previous) { ?>
+<?php 
+	}
+	if ($my_cp != $v1_previous) { 
+?>
     					<option value="<?php echo $cp_p1_build; ?>">ClassicPress v<?php echo $v1_previous; ?></option>
 <?php } ?>
 					</optgroup>
 					<optgroup label="WordPress Builds">
 <?php if ($wp_version != $cp_api_parameters['wordpress']['max']) { ?>
 						<option value="<?php echo $cp_api_parameters['links']['WordPress Latest']; ?>">WordPress v<?php echo $cp_api_parameters['wordpress']['max']; ?></option>
-<?php }
-if (!$is_wp && $wp_v6 == $wp_version) { $wp_check = "0.0.0"; } else { $wp_check = $wp_version; }
-if ($wp_check != $wp_v6) { ?>
+<?php
+	}
+	if (!$is_wp && $wp_v6 == $wp_version) { $wp_check = "0.0.0"; } else { $wp_check = $wp_version; }
+	if ($wp_check != $wp_v6) { 
+?>
     					<option value="<?php echo $cp_api_parameters['links']['WordPress 6.2.x']; ?>">WordPress v<?php echo $wp_v6; ?></option>
-<?php } ?>
-<?php 	// WPv4.9 DOES NOT WORK with php8 - Block the option here
-if (!$is_wp && $wp_v4 == $wp_version) { $wp_check = "0.0.0"; } else { $wp_check = $wp_version; }
-if ( version_compare( PHP_VERSION, $php_version_49, 'lt' ) && $wp_check != $wp_v4 ) {
+<?php 
+	}
+// WPv4.9 DOES NOT WORK with php8 - Block the option here
+	if (!$is_wp && $wp_v4 == $wp_version) { $wp_check = "0.0.0"; } else { $wp_check = $wp_version; }
+	if ( version_compare( PHP_VERSION, $php_version_49, 'lt' ) && $wp_check != $wp_v4 ) {
 ?>
     					<option value="<?php echo $cp_api_parameters['links']['WordPress 4.9.x']; ?>">WordPress v<?php echo $wp_v4; ?></option>
 <?php } ?>

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -477,10 +477,11 @@ if (strpos($cp_version, 'migration')) {
 
 	// Check: Conflicting Theme
 	$theme = wp_get_theme();
+	// TEMPORARY HARD CODED DEFAULT THEME
 	$theme_name = 'Twenty Sixteen';
 	$theme_url = 'https://wordpress.org/themes/twentysixteen/';
-	$default_theme = " <a href='$theme_url'>$theme_name</a> ";
-	$theme_info = "<li>The safest way of switching to ClassicPress is by (temporarily) installing and activating the theme <strong>$default_theme</strong>, which works in ClassicPress and WordPress.</li>";
+	$default_theme = "<a href='$theme_url'>$theme_name</a>";
+	$theme_info = "<li>The safest way of switching to ClassicPress is by (temporarily) installing and activating the fully compatible theme <strong>$default_theme</strong>.</li>";
 	$fse_info = "<br>Block themes may work in ClassicPress but Full Screen Editor themes will not, you will have to test the theme(s) you plan to use and verify that they work correctly.";
 	if (
 		in_array( $theme->stylesheet, (array) $cp_api_parameters['themes'] ) ||
@@ -541,7 +542,7 @@ if (strpos($cp_version, 'migration')) {
 	$plugin_headers = array( 'Name' => 'Plugin Name', 'RequiresWP'  => 'Requires at least' );
 	$declared_incompatible_plugins = array();
 	$undeclared_compatibility_plugins = array();
-	$plugin_info = "<br>Plugins that require Blocks might not work in ClassicPress, you should test the plugins you plan to use and verify that they work correctly.";
+	$plugin_info = "<br>Plugins that require Blocks might not work in ClassicPress, you should test the plugins you plan to use and verify they work correctly.";
 
 	// Start by checking if plugins have declared they require WordPress 5.0 or higher
 	foreach ( $plugins as $plugin ) {
@@ -615,15 +616,15 @@ if (strpos($cp_version, 'migration')) {
 		$preflight_checks['plugins'] = true;
 		echo "<tr>\n<td>$icon_preflight_warn</td>\n<td>\n<p>\n";
 		_e(
-			'We have detected one or more plugins that may require Blocks or fail to declare a minimum compatible WordPress version.'.$plugin_info,
+			'We have detected one or more plugins that may require Blocks or fail to declare a compatible WordPress version.'.$plugin_info,
 			'switch-to-classicpress'
 		);
 		echo "<br>\n";
 		 _e(
-			'We suggest (temporarily) deactivating the following plugins would be the safest way to migrate your site to ClassicPress:',
+			'<li>The safest way of switching to ClassicPress is to (temporarily) deactivate the following plugin(s):</li>',
 			'switch-to-classicpress'
 		);
-		echo "<br>\n";
+		//echo "<br>\n";
 		/* translators: List of conflicting plugin names */
 		printf( __(
 			'<strong>%s<strong>',

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -916,8 +916,14 @@ function classicpress_show_migration_blocked_info() {
  */
 function classicpress_show_advanced_migration_controls( $ok = true ) {
 	$cp_api_parameters = classicpress_migration_parameters();
+	$cp_api_error = false;
+	if (is_wp_error( $cp_api_parameters ) ) {
+		$cp_api_parameters = [];
+		$cp_api_error = true;
+	}
 	$cp_versions = get_cp_versions();
 	// Get version information here
+	if ( $cp_api_error === false ) {
 		$cp_cv = substr($cp_api_parameters['classicpress']['version'], 0, strpos($cp_api_parameters['classicpress']['version'], '+'));
 		$v2_previous = get_previous_version($cp_cv, $cp_versions);
 		$v2_prev_url = get_migration_from_cp_version($v2_previous);
@@ -926,6 +932,7 @@ function classicpress_show_advanced_migration_controls( $ok = true ) {
 		$v1_prev_url = get_migration_from_cp_version($v1_previous);
 		$wp_v6 = substr($cp_api_parameters['links']['WordPress 6.2.x'], 32, -4);
 		$wp_v4 = substr($cp_api_parameters['links']['WordPress 4.9.x'], 32, -4);
+	}
 	$is_wp = ! function_exists( 'classicpress_version' );
 	global $wp_version;
 	if (!$is_wp) {
@@ -936,10 +943,12 @@ function classicpress_show_advanced_migration_controls( $ok = true ) {
 			$my_cp = preg_replace('#[+-].*$#', '', $cp_version);
 		}
 		// Build Proper URL here (ClassicPress can use Release)
-		$cp_cv_build = getReleaseFromCPVersion($cp_cv);
-		$cp_p2_build = getReleaseFromCPVersion($v2_previous);
-		$cp_v1_build = getReleaseFromCPVersion($cp_v1);
-		$cp_p1_build = getReleaseFromCPVersion($v1_previous);
+		if ( $cp_api_error === false ) {
+			$cp_cv_build = getReleaseFromCPVersion($cp_cv);
+			$cp_p2_build = getReleaseFromCPVersion($v2_previous);
+			$cp_v1_build = getReleaseFromCPVersion($cp_v1);
+			$cp_p1_build = getReleaseFromCPVersion($v1_previous);
+		}
 	} else {
 		$my_cp = "0.0.0";
 		// Build Proper URL here (WordPress must use Migration)
@@ -1036,6 +1045,7 @@ function classicpress_show_advanced_migration_controls( $ok = true ) {
 					?>
 				</td>
 			</tr>
+			<?php if ( $cp_api_error === false ) : ?>
 			<tr>
 				<th colspan="2">
 				<label for="picker" id="picker-label">Enter or Select a Custom Build URL</label>
@@ -1082,6 +1092,7 @@ function classicpress_show_advanced_migration_controls( $ok = true ) {
 					</select>
 				</th>
 			</tr>
+			<?php endif; ?>
 			<tr>
 				<th scope="row">
 					<label for="cp-build-url">

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -478,8 +478,8 @@ if (strpos($cp_version, 'migration')) {
 	// Check: Conflicting Theme
 	$theme = wp_get_theme();
 	// TEMPORARY HARD CODED DEFAULT THEME
-	$theme_name = $cp_api_parameters['defaults']['theme_name'];
-	$theme_url = $cp_api_parameters['defaults']['theme_url'];
+	$theme_name = 'Twenty Sixteen';
+	$theme_url = 'https://wordpress.org/themes/twentysixteen/';
 	$default_theme = "<a href='$theme_url'>$theme_name</a>";
 	$theme_info = "<li>The safest way of switching to ClassicPress is by (temporarily) installing and activating the fully compatible theme <strong>$default_theme</strong>.</li>";
 	$fse_info = "<br>Block themes may work in ClassicPress but Full Screen Editor themes will not, you will have to test the theme(s) you plan to use and verify that they work correctly.";

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -477,7 +477,6 @@ if (strpos($cp_version, 'migration')) {
 
 	// Check: Conflicting Theme
 	$theme = wp_get_theme();
-	// TEMPORARY HARD CODED DEFAULT THEME
 	$theme_name = $cp_api_parameters['defaults']['theme_name'];
 	$theme_url = $cp_api_parameters['defaults']['theme_url'];
 	$default_theme = "<a href='$theme_url'>$theme_name</a>";

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -478,8 +478,8 @@ if (strpos($cp_version, 'migration')) {
 	// Check: Conflicting Theme
 	$theme = wp_get_theme();
 	// TEMPORARY HARD CODED DEFAULT THEME
-	$theme_name = 'Twenty Sixteen';
-	$theme_url = 'https://wordpress.org/themes/twentysixteen/';
+	$theme_name = $cp_api_parameters['defaults']['theme_name'];
+	$theme_url = $cp_api_parameters['defaults']['theme_url'];
 	$default_theme = "<a href='$theme_url'>$theme_name</a>";
 	$theme_info = "<li>The safest way of switching to ClassicPress is by (temporarily) installing and activating the fully compatible theme <strong>$default_theme</strong>.</li>";
 	$fse_info = "<br>Block themes may work in ClassicPress but Full Screen Editor themes will not, you will have to test the theme(s) you plan to use and verify that they work correctly.";

--- a/switch-to-classicpress.php
+++ b/switch-to-classicpress.php
@@ -222,7 +222,6 @@ function classicpress_migration_parameters() {
  *
  * @return array|false Array of CP versions or false on API failure.
  */
-/*
 function get_cp_versions() {
 	$cp_versions = get_transient( 'classicpress_release_versions' );
 
@@ -299,4 +298,41 @@ function get_migration_from_cp_version($version) {
 	$url        = 'https://github.com/ClassyBot/ClassicPress-v'.$major.'-nightly/releases/download/'.$version.'%2Bmigration.'.$day.'/ClassicPress-nightly-'.$version.'-migration.'.$day.'.zip';
 	return $url;
 }
-*/
+
+/**
+ * Get release URL.
+ *
+ * @param string $version  Version to retrive migration URL.
+ *
+ * @return string          URL for release.
+ */
+function getReleaseFromCPVersion($version) {
+	return 'https://github.com/ClassicPress/ClassicPress-release/archive/refs/tags/'.$version.'.zip';
+}
+
+/**
+ * Get previous release version.
+ *
+ * @param string $version   Version to get previous release.
+ * @param array  $versions  Array of ClassicPress versions as
+ *                          returned by getCPVersions().
+ *                          Used for caching.
+ *
+ * @return string|bool      Previous version. False if not found.
+ */
+function get_previous_version($version, $versions = []) {
+	if (empty($versions)) {
+//		$versions = self::getCPVersions();
+		$versions = get_cp_versions();
+	} else {
+		usort($versions, 'version_compare');
+	}
+	if(!in_array($version, $versions)) {
+		return false;
+	}
+	$pos = array_search($version, $versions, true);
+	if(!isset($versions[$pos - 1])) {
+		return false;
+	}
+	return $versions[$pos - 1];;
+}

--- a/switch-to-classicpress.php
+++ b/switch-to-classicpress.php
@@ -259,7 +259,7 @@ if ( ! $cp_versions ) {
 
 	// Get only stable releases
 	foreach ($cp_versions as $key => $version) {
-		if(!str_contains($version, 'nightly') && !str_contains($version, 'rc') && !str_contains($version, 'alpha') && !str_contains($version, 'beta')) {
+		if(!strpos($version, 'nightly') && !strpos($version, 'rc') && !strpos($version, 'alpha') && !strpos($version, 'beta')) {
 			continue;
 		}
 		unset($cp_versions[$key]);


### PR DESCRIPTION
- Adjust checks, notifications and information text as needed for CP v2
- Warn that Migration requires Re-Install (reminder if you go back into the plugin)
- Chat link changed from Slack to Zulip
- Add smart drop down to Advanced Controls
- Offer CP v1 & v2 current and one version back (unless no previous as with 2 right now)
- Offer WP current, 6.3.x and 4.9.x (4.9 offered only if running php7)
- Offer release version if running CP migration version
- Will not offer what you already have
- Suggest CP Default theme (temporary hard coded - API needs adjustment)