### PR TITLE
Update admin-page.php to eliminate console warning

### DIFF
--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -122,10 +122,13 @@ table#cp-preflight-checks {
 </style>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-	document.getElementById( 'cp-show-advanced-migration-form' ).addEventListener( 'click', function() {
-		document.getElementById( 'cp-advanced-migration-form' ).classList.remove( 'hidden' );
-		this.remove();
-	} );
+	var showForm = document.getElementById( 'cp-show-advanced-migration-form' );
+	if ( showForm != null ) {
+		showForm.addEventListener( 'click', function() {
+			document.getElementById( 'cp-advanced-migration-form' ).classList.remove( 'hidden' );
+			this.remove();
+		} );
+	}
 } );
 </script>
 <?php


### PR DESCRIPTION
This eliminates the following warning in the browser console:
```
Uncaught TypeError: document.getElementById(...) is null
```