### PR TITLE
Update admin-page.php to change h3 headers to h2 for accessibility

### DIFF
--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -270,7 +270,7 @@ function classicpress_check_can_migrate() {
 <?php
 if (strpos($cp_version, 'migration')) {
 			_e(
-				"<h3>You're almost done switching to ClassicPress v".preg_replace('#[+-].*$#', '', $cp_version)."!</h3>",
+				"<h2>You're almost done switching to ClassicPress v".preg_replace('#[+-].*$#', '', $cp_version)."!</h2>",
 				'switch-to-classicpress'
 			);
 			_e(
@@ -279,7 +279,7 @@ if (strpos($cp_version, 'migration')) {
 			);
 } else {
 			_e(
-				"<h3>Good job, you're running ClassicPress v".preg_replace('#[+-].*$#', '', $cp_version)."!</h3>",
+				"<h2>Good job, you're running ClassicPress v".preg_replace('#[+-].*$#', '', $cp_version)."!</h2>",
 				'switch-to-classicpress'
 			);
 }


### PR DESCRIPTION
Headers must always descend sequentially. Since the previous header on the page for each of those changed in this PR is an `h1`, the two headers must be `h2`s.

Note that ascending headers do not need to be sequential.