### PR TITLE
Update to Plugin and Theme Warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,4 +230,5 @@ supports migrating multisite WordPress installations to ClassicPress.
 
 - Change Plugin and Theme Checks to explain safest method, but only warn if not followed
 - Change Core File check to show any modified files on the page rather than in the console
+- Display override function info for unsupported WP versions when applicable
 - Correct links and update wording as needed

--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ supports migrating multisite WordPress installations to ClassicPress.
 - Adjust checks, notifications and information text as needed for CP v2
 - Warn that Migration requires Re-Install (reminder if you go back into the plugin)
 - Chat link changed from Slack to Zulip
-- Offer CP v1 & v2 current and one version back (unless no previous as with 2 right now)
-- Offer WP current, 6.3.x and 4.9.x (4.9 offered only if running PHP 7)
+- Offer CP v1 & v2 current and one version back (unless no previous)
+- Offer WP current, 6.2.x and 4.9.x (4.9 offered only if running PHP 7)
 - Offer release version if running CP migration version
 - Will not offer re-installation
 - Suggest a ClassicPress Default theme
@@ -225,3 +225,9 @@ supports migrating multisite WordPress installations to ClassicPress.
 ### 1.5.2
 
 - Update Code to CPCS
+
+### 1.5.3
+
+- Change Plugin and Theme Checks to explain safest method, but only warn if not followed
+- Change Core File check to show any modified files on the page rather than in the console
+- Correct links and update wording as needed

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -487,12 +487,14 @@ if (strpos($cp_version, 'migration')) {
 	// TODO: Add instructions if WP too old.
 	echo "</td></tr>\n";
 
-	// Check: Conflicting Theme
+	// Theme Check
 	$theme = wp_get_theme();
 	$theme_name = $cp_api_parameters['defaults']['theme_name'];
 	$theme_url = $cp_api_parameters['defaults']['theme_url'];
 	$default_theme = "<a href='$theme_url'>$theme_name</a>";
-	$theme_info = "<li>The safest way of switching to ClassicPress is by (temporarily) installing and activating the fully compatible theme <strong>$default_theme</strong>.</li>";
+	$theme_info = "<strong>The safest way of switching to ClassicPress is to install and activate the fully compatible theme <em>$default_theme</em>.</strong>
+	<br>You can <strong class='cp-emphasis'>Continue at Your Own Risk</strong> with your current theme, but you may experience issues if the theme is not compatible with ClassicPress.";	
+/* THEME CHECKS DISABLED - WARN INSTEAD
 	$fse_info = "<br>Block and Full Screen Editor themes may work in ClassicPress, but you will have to test the theme(s) you plan to use and verify that they work correctly.";
 	if (
 		in_array( $theme->stylesheet, (array) $cp_api_parameters['themes'] ) ||
@@ -500,7 +502,7 @@ if (strpos($cp_version, 'migration')) {
 	) {
 		$preflight_checks['theme'] = false;
 		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_fail) . "</td>\n<td>\n<p>\n";
-		/* translators: active theme name */
+		// translators: active theme name
 		printf( wp_kses_post(
 			'It looks like you are using the <strong>%1$s</strong> theme. Unfortunately, %1$s is known to be incompatible with ClassicPress.%2$s',
 			'switch-to-classicpress'
@@ -515,7 +517,7 @@ if (strpos($cp_version, 'migration')) {
 		$preflight_checks['theme'] = false;
 		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_fail) . "</td>\n<td>\n<p>\n";
 		printf( wp_kses_post(
-			/* translators: active theme name */
+			// translators: active theme name
 			'It looks like you are using the <strong>%1$s</strong> theme. Unfortunately, %1$s is probably using FSE functions and may not be compatible with ClassicPress.%2$s',
 			'switch-to-classicpress'
 //      ), $theme->name, $theme->get( 'RequiresWP' ) );
@@ -526,6 +528,8 @@ if (strpos($cp_version, 'migration')) {
 			'switch-to-classicpress'
 		);
 	} elseif ( $theme->name === $theme_name ) {
+*/
+	if ( $theme->name === $theme_name ) {
 		$preflight_checks['theme'] = true;
 		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_pass) . "</td>\n<td>\n<p>\n";
 		printf( wp_kses_post(
@@ -536,8 +540,8 @@ if (strpos($cp_version, 'migration')) {
 		$preflight_checks['theme'] = true;
 		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_warn) . "</td>\n<td>\n<p>\n";
 		printf( wp_kses_post(
-			/* translators: active theme name */
-			'It looks like you are using the <strong>%1$s</strong> theme. We are not aware of any incompatibilities between %1$s and ClassicPress.',
+			// translators: active theme name
+			'It looks like you are using the theme <strong>%1$s</strong>, you should test the theme(s) you plan to use after migration and verify that they work correctly.',
 			'switch-to-classicpress'
 		), esc_html( $theme->name ) );
 		echo "<br>\n";
@@ -548,21 +552,26 @@ if (strpos($cp_version, 'migration')) {
 	}
 	echo "</p></td></tr>\n";
 
-	// Check: Conflicting Plugins
+	// Plugins Check
 	$plugins = get_option( 'active_plugins' );
 	$plugin_headers = array( 'Name' => 'Plugin Name', 'RequiresWP'  => 'Requires at least' );
 	$declared_incompatible_plugins = array();
 	$undeclared_compatibility_plugins = array();
-	$plugin_info = "<br>Plugins that require Blocks might not work in ClassicPress, you should test the plugins you plan to use and verify they work correctly.";
+	$plugin_info = "It looks like you have active plugins, you should test the plugins you plan to use after migration and verify they work correctly.";
 
 	// Start by checking if plugins have declared they require WordPress 5.0 or higher
 	foreach ( $plugins as $plugin ) {
 		if ( in_array( $plugin, $cp_api_parameters['plugins'] ) ) {
 			continue;
 		}
+//		echo $plugin;
+		if ( $plugin === 'ClassicPress-Migration-Plugin/switch-to-classicpress.php' ) {
+   			continue; // Skip this plugin
+		}
+  // Get the plugin data
 		$plugin_data = get_file_data( WP_PLUGIN_DIR . '/' . $plugin, $plugin_headers );
 		$plugin_name = $plugin_data['Name'];
-		if ( version_compare( $plugin_data['RequiresWP'], '5.0' ) >= 0 ) {
+		if ( version_compare( $plugin_data['RequiresWP'], '1.0' ) >= 0 ) {
 			$undeclared_compatibility_plugins[ $plugin ] = $plugin_name;
 		} else {
 			$plugin_files = get_plugin_files( $plugin );
@@ -574,7 +583,7 @@ if (strpos($cp_version, 'migration')) {
 					continue;
 				}
 				$readme_data = get_file_data( WP_PLUGIN_DIR . '/' . $readme, $plugin_headers );
-				if ( version_compare( $readme_data['RequiresWP'], '5.0' ) >= 0 ) {
+				if ( version_compare( $readme_data['RequiresWP'], '1.0' ) >= 0 ) {
 					$undeclared_compatibility_plugins[ $plugin ] = $plugin_name;
 					continue;
 				}
@@ -590,6 +599,7 @@ if (strpos($cp_version, 'migration')) {
 	}
 
 	// Compare active plugins with API response of known conflicting plugins
+	$cp_api_parameters['plugins'] === ""; // DISABLES THIS CHECK
 	if (
 		$plugins !== array_diff( $plugins, $cp_api_parameters['plugins'] ) ||
 		! empty( $declared_incompatible_plugins )
@@ -617,7 +627,7 @@ if (strpos($cp_version, 'migration')) {
 			'switch-to-classicpress'
 		);
 		echo "<br>\n";
-		/* translators: List of conflicting plugin names */
+		// translators: List of conflicting plugin names
 		printf( wp_kses_post(
 			'<strong>%s<strong>',
 			'switch-to-classicpress'
@@ -626,26 +636,29 @@ if (strpos($cp_version, 'migration')) {
 		$preflight_checks['plugins'] = true;
 		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_warn) . "</td>\n<td>\n<p>\n";
 		echo wp_kses_post(
-			'We have detected one or more plugins that may require Blocks or fail to declare a compatible WordPress version.'.$plugin_info,
+			$plugin_info,
 			'switch-to-classicpress'
 		);
 		echo "<br>\n";
 		echo wp_kses_post(
-			'<li>The safest way of switching to ClassicPress is to (temporarily) deactivate the following plugin(s):</li>',
+			"<strong>The safest way of switching to ClassicPress is to (temporarily) deactivate your plugins, except <em>Switch to ClassicPress</em>.</strong>
+			<br>You can <strong class='cp-emphasis'>Continue at Your Own Risk</strong> with active plugins, but you may experience issues if any plugins are not compatible with ClassicPress.",
 			'switch-to-classicpress'
 		);
 		//echo "<br>\n";
-		/* translators: List of conflicting plugin names */
+		// translators: List of conflicting plugin names - DISPLAY DISABLED BELOW
+/*	
 		printf( wp_kses_post(
 			'<strong>%s<strong>',
 			'switch-to-classicpress'
 		), esc_html( implode( ', ', $undeclared_compatibility_plugins ) ) );
+*/
 		echo "</p></td></tr>\n";
 		} else {
 		$preflight_checks['plugins'] = true;
-		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_warn) . "</td>\n<td>\n<p>\n";
+		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_pass) . "</td>\n<td>\n<p>\n";
 		esc_html_e(
-			'We are not aware that any of your active plugins are incompatible with ClassicPress.',
+			'It looks like you have no plugins or have deactived plugins other than Switch to ClassicPress, this is the safest to migrate your site to ClassicPress.',
 			'switch-to-classicpress'
 		);
 		}
@@ -741,7 +754,7 @@ if (strpos($cp_version, 'migration')) {
 	}
 	echo "<p>\n";
 	esc_html_e(
-		'Your WordPress core files will be overwritten.',
+		'WordPress core files will be overwritten during the migration.',
 		'switch-to-classicpress'
 	);
 	echo "\n<br>\n";
@@ -763,10 +776,15 @@ if (strpos($cp_version, 'migration')) {
 	} else {
 		echo '<strong class="cp-emphasis">';
 		esc_html_e(
-			'Modified core files detected. These customizations will be lost.',
+			'Modified core files detected. These customizations will be lost:',
 			'switch-to-classicpress'
 		);
 		echo "</strong>\n<br>\n";
+		foreach ( $modified_files as $file ) {
+			// translators: modified core file name
+			echo esc_html( sprintf( ' - %s', $file ) ) . "<br>\n";
+		}
+/*
 		echo wp_kses_post(
 			'If you have JavaScript enabled, you can see a list of modified files <strong>in your browser console</strong>.',
 			'switch-to-classicpress'
@@ -774,6 +792,7 @@ if (strpos($cp_version, 'migration')) {
 		echo "\n<script>console.log( 'modified core files:', ";
 		echo wp_json_encode( $modified_files );
 		echo ' );</script>';
+*/
 	}
 	echo "\n</p>\n";
 	echo "</td></tr>\n";
@@ -823,7 +842,7 @@ if (strpos($cp_version, 'migration')) {
  * Show the controls and information needed to migrate to ClassicPress.
  *
  * NOTE: ONLY CALL THIS FUNCTION IF ALL PRE-FLIGHT CHECKS HAVE PASSED!
- * Otherwise you *will* end up with a broken site!
+ * Otherwise you could end up with a broken site!
  *
  * @since 0.1.0
  */

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -498,7 +498,7 @@ if (strpos($cp_version, 'migration')) {
 	$default_theme = "<a href='$theme_url'>$theme_name</a>";
 	$theme_info = "<strong>The safest way of switching to ClassicPress is to install and activate the fully compatible theme <em>$default_theme</em>.</strong>
 	<br>You can <strong class='cp-emphasis'>Continue at Your Own Risk</strong> with your current theme, but you may experience issues if the theme is not compatible with ClassicPress.";	
-/* THEME CHECKS DISABLED / WARN ONLY - (I kept this code for referance but a rework could be done to remove it and more code that is no longer needed)
+/* THEME CHECKS DISABLED / WARN ONLY (Since v1.7) - (I kept this code for referance but a rework could be done to remove it and more code that is no longer needed)
 	$fse_info = "<br>Block and Full Screen Editor themes may work in ClassicPress, but you will have to test the theme(s) you plan to use and verify that they work correctly.";
 	if (
 		in_array( $theme->stylesheet, (array) $cp_api_parameters['themes'] ) ||
@@ -565,13 +565,14 @@ if (strpos($cp_version, 'migration')) {
 
 	// Start by checking if plugins have declared they require WordPress 5.0 or higher
 	// CHANGED TO CHECK FOR WP 1.0 OR HIGHER / ALL PLUGINS
+	// DISABLED (Since v1.7)
+	/*
 	foreach ( $plugins as $plugin ) {
 		if ( in_array( $plugin, $cp_api_parameters['plugins'] ) ) {
 			continue;
 		}
-//		echo $plugin;
 		$migchk = explode ( '/', $plugin );
-		if ( $migchk[1] === 'switch-to-classicpress.php' ) {
+		if ( ( isset($migchk[1]) ? $migchk[1] : '' ) === 'switch-to-classicpress.php' ) {
 			continue; // skip the Switch to ClassicPress plugin
 		}
   		// Get the plugin data
@@ -603,9 +604,10 @@ if (strpos($cp_version, 'migration')) {
 			$undeclared_compatibility_plugins[ $plugin ] = $plugin_name;
 		}
 	}
+	*/
 
 	// Compare active plugins with API response of known conflicting plugins
-	$cp_api_parameters['plugins'] === ""; // DISABLES THIS CHECK
+	$cp_api_parameters['plugins'] = []; // DISABLES THIS CHECK (Since v1.7)
 	if (
 		$plugins !== array_diff( $plugins, $cp_api_parameters['plugins'] ) ||
 		! empty( $declared_incompatible_plugins )
@@ -638,7 +640,9 @@ if (strpos($cp_version, 'migration')) {
 			'<strong>%s<strong>',
 			'switch-to-classicpress'
 		), esc_html( implode( ', ', $conflicting_plugin_names ) ) );
-		} elseif ( ! empty( $undeclared_compatibility_plugins ) ) {
+		// } elseif ( ! empty( $undeclared_compatibility_plugins ) ) {
+		// CHANGED TO AVOID LOOPING TROUGH PLUGINS ABOVE (Since v.1.7)
+		} elseif ( count($plugins) > 1 ) {
 		$preflight_checks['plugins'] = true;
 		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_warn) . "</td>\n<td>\n<p>\n";
 		echo wp_kses_post(
@@ -651,7 +655,8 @@ if (strpos($cp_version, 'migration')) {
 			<br>You can <strong class='cp-emphasis'>Continue at Your Own Risk</strong> with active plugins, but you may experience issues if any plugins are not compatible with ClassicPress.",
 			'switch-to-classicpress'
 		);
-		// translators: List of conflicting plugin names - UNCOMMENT TO DISPLAY
+		// translators: List of conflicting plugin names
+		// UNCOMMENT TO DISPLAY (Since v1.7)
 /*	
 		echo "<br>\n";
 		printf( wp_kses_post(

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -404,9 +404,9 @@ if (strpos($cp_version, 'migration')) {
 	$wp_version_max = $cp_api_parameters['wordpress']['max'];
 	/* translators: 1: minimum supported WordPress version, 2: maximum supported WordPress version */
 	$wp_version_check_intro_message = sprintf( __(
-		'This plugin supports WordPress versions <strong>%1$s</strong> to <strong>%2$s</strong> (and some newer development versions).',
+		'This plugin supports WordPress versions <strong>%1$s</strong> to <strong>%2$s</strong> (and some newer development versions).<br>You are running WordPress version <strong>%3$s</strong>.',
 		'switch-to-classicpress'
-	), $wp_version_min, $wp_version_max );
+	), $wp_version_min, $wp_version_max, $wp_version );
 	$wp_version_check_intro_message .= "<br>\n";
 
 	if (
@@ -434,17 +434,17 @@ if (strpos($cp_version, 'migration')) {
 			echo "<p>\n";
 			echo wp_kses_post( $wp_version_check_intro_message );
 			echo wp_kses_post(
-				'The preflight check for supported WordPress versions has been <strong class="cp-emphasis">disabled</strong>.',
+				'The check for supported WordPress versions has been <strong class="cp-emphasis">Manually Disabled</strong>.',
 				'switch-to-classicpress'
 			);
 			echo "<br>\n";
 			esc_html_e(
-				'We cannot guarantee that the migration process is going to work, and it may even leave your current installation partially broken.',
+				'We cannot guarantee that the migration process is going to work, and it may leave your current installation broken.',
 				'switch-to-classicpress'
 			);
 			echo "<br>\n";
 			echo wp_kses_post(
-				'<strong class="cp-emphasis">Proceed at your own risk!</strong>',
+				'<strong class="cp-emphasis">Proceed At Your Own Risk!</strong>',
 				'switch-to-classicpress'
 			);
 			echo "<br>\n";
@@ -453,6 +453,9 @@ if (strpos($cp_version, 'migration')) {
 			echo wp_kses_post( "<tr>\n<td>$icon_preflight_fail</td>\n<td>\n" );
 			echo "<p>\n";
 			echo wp_kses_post( $wp_version_check_intro_message );
+			echo wp_kses_post( "You can enable migration from this version of WordPress <strong class='cp-emphasis'>At Your
+		Own Risk</strong><br>Use the following code in your current theme's
+		`functions.php` file or a mu-plugin to allow migration:<br><code>add_filter( 'classicpress_ignore_wp_version', '__return_true' );</code>" );
 		}
 	} else {
 		$preflight_checks['wp_version'] = true;
@@ -464,15 +467,16 @@ if (strpos($cp_version, 'migration')) {
 		echo "<p>\n";
 		echo wp_kses_post( $wp_version_check_intro_message );
 	}
-	/* translators: current WordPress version */
+	/* translators: current WordPress version
 	printf( wp_kses_post(
 		'You are running WordPress version <strong>%s</strong>.',
 		'switch-to-classicpress'
 	), esc_html( $wp_version ) );
+	*/
 	if ( substr( $wp_version, 0, 1 ) >= '5' && $preflight_checks['wp_version'] ) {
-		echo "<br>\n";
+		//echo "<br>\n";
 		esc_html_e(
-			'Migration is supported, but content edited with the WordPress Block Editor may not be fully compatible with ClassicPress.',
+			'Content edited with the WordPress Block Editor may not be fully compatible with ClassicPress.',
 			'switch-to-classicpress'
 		);
 /* THIS NEXT LINE IS DISABLED - I THINK THE ABOVE IS ENOUGH

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -498,7 +498,7 @@ if (strpos($cp_version, 'migration')) {
 	$default_theme = "<a href='$theme_url'>$theme_name</a>";
 	$theme_info = "<strong>The safest way of switching to ClassicPress is to install and activate the fully compatible theme <em>$default_theme</em>.</strong>
 	<br>You can <strong class='cp-emphasis'>Continue at Your Own Risk</strong> with your current theme, but you may experience issues if the theme is not compatible with ClassicPress.";	
-/* THEME CHECKS DISABLED / WARN ONLY (Since v1.7) - (I kept this code for referance but a rework could be done to remove it and more code that is no longer needed)
+/* THEME CHECKS DISABLED / WARN ONLY (Since v1.6) - (I kept this code for referance but a rework could be done to remove it and more code that is no longer needed)
 	$fse_info = "<br>Block and Full Screen Editor themes may work in ClassicPress, but you will have to test the theme(s) you plan to use and verify that they work correctly.";
 	if (
 		in_array( $theme->stylesheet, (array) $cp_api_parameters['themes'] ) ||
@@ -565,7 +565,7 @@ if (strpos($cp_version, 'migration')) {
 
 	// Start by checking if plugins have declared they require WordPress 5.0 or higher
 	// CHANGED TO CHECK FOR WP 1.0 OR HIGHER / ALL PLUGINS
-	// DISABLED (Since v1.7)
+	// DISABLED (Since v1.6)
 	/*
 	foreach ( $plugins as $plugin ) {
 		if ( in_array( $plugin, $cp_api_parameters['plugins'] ) ) {
@@ -607,7 +607,7 @@ if (strpos($cp_version, 'migration')) {
 	*/
 
 	// Compare active plugins with API response of known conflicting plugins
-	$cp_api_parameters['plugins'] = []; // DISABLES THIS CHECK (Since v1.7)
+	$cp_api_parameters['plugins'] = []; // DISABLES THIS CHECK (Since v1.6)
 	if (
 		$plugins !== array_diff( $plugins, $cp_api_parameters['plugins'] ) ||
 		! empty( $declared_incompatible_plugins )
@@ -641,7 +641,7 @@ if (strpos($cp_version, 'migration')) {
 			'switch-to-classicpress'
 		), esc_html( implode( ', ', $conflicting_plugin_names ) ) );
 		// } elseif ( ! empty( $undeclared_compatibility_plugins ) ) {
-		// CHANGED TO AVOID LOOPING TROUGH PLUGINS ABOVE (Since v.1.7)
+		// CHANGED TO AVOID LOOPING TROUGH PLUGINS ABOVE (Since v.1.6)
 		} elseif ( count($plugins) > 1 ) {
 		$preflight_checks['plugins'] = true;
 		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_warn) . "</td>\n<td>\n<p>\n";
@@ -656,7 +656,7 @@ if (strpos($cp_version, 'migration')) {
 			'switch-to-classicpress'
 		);
 		// translators: List of conflicting plugin names
-		// UNCOMMENT TO DISPLAY (Since v1.7)
+		// UNCOMMENT TO DISPLAY (Since v1.6)
 /*	
 		echo "<br>\n";
 		printf( wp_kses_post(

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -224,7 +224,7 @@ function classicpress_show_admin_page() {
 				'For support, suggestions for improvement, or general discussion about how the plugin works, visit us in our <a href="%1$s">support forum</a> or <a href="%2$s">Zulip chat</a>.',
 				'switch-to-classicpress'
 			),
-			'https://forums.classicpress.net/c/support/migration-plugin',
+			'https://forums.classicpress.net/tags/c/plugins/9/migration-plugin',
 			'https://classicpress.zulipchat.com/register/'
 		); ?></li>
 		<li><?php printf(
@@ -565,8 +565,9 @@ if (strpos($cp_version, 'migration')) {
 			continue;
 		}
 //		echo $plugin;
-		if ( $plugin === 'ClassicPress-Migration-Plugin/switch-to-classicpress.php' ) {
-   			continue; // Skip this plugin
+		$migchk = explode ( '/', $plugin );
+		if ( $migchk[1] === 'switch-to-classicpress.php' ) {
+			continue; // Skip this plugin
 		}
   // Get the plugin data
 		$plugin_data = get_file_data( WP_PLUGIN_DIR . '/' . $plugin, $plugin_headers );
@@ -647,18 +648,18 @@ if (strpos($cp_version, 'migration')) {
 		);
 		//echo "<br>\n";
 		// translators: List of conflicting plugin names - DISPLAY DISABLED BELOW
-/*	
+//	
 		printf( wp_kses_post(
 			'<strong>%s<strong>',
 			'switch-to-classicpress'
 		), esc_html( implode( ', ', $undeclared_compatibility_plugins ) ) );
-*/
+//
 		echo "</p></td></tr>\n";
 		} else {
 		$preflight_checks['plugins'] = true;
 		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_pass) . "</td>\n<td>\n<p>\n";
 		esc_html_e(
-			'It looks like you have no plugins or have deactived plugins other than Switch to ClassicPress, this is the safest to migrate your site to ClassicPress.',
+			'It looks like you have no plugins or have deactived plugins other than Switch to ClassicPress, this is the safest way to migrate your site to ClassicPress.',
 			'switch-to-classicpress'
 		);
 		}
@@ -929,7 +930,7 @@ function classicpress_show_migration_blocked_info() {
 				'If you\'re not sure how to fix the issues above, you can ask for help in our <a href="%s">Support Forum</a>.',
 				'switch-to-classicpress'
 			),
-			'https://forums.classicpress.net/c/support/migration-plugin'
+			'https://forums.classicpress.net/tags/c/plugins/9/migration-plugin'
 		);
 		?>
 	</p>
@@ -1055,13 +1056,13 @@ function classicpress_show_advanced_migration_controls( $ok = true ) {
 				<td>
 					<p>
 						<?php echo wp_kses_post(
-							'If all requirements for your custom version have been met, then migration should complete.</p><p>That does not mean it will be successful in every case and<strong class="cp-emphasis"> Older Versions May Not be Secure!</strong></p>',
+							'If all requirements for your custom version have been met, then migration should complete.</p><p>That does not mean it will work in every case and<strong class="cp-emphasis"> Older Versions may have Password or Security Issues!</strong></p>',
 							'switch-to-classicpress'
 						); ?>
 					</p>
 					<p>
 						<?php echo wp_kses_post(
-							'Please, make a <strong class="cp-emphasis">Complete Backup of your Site</strong> before using this tool<strong class="cp-emphasis"> At Your Own Risk!</strong>',
+							'Please, make a <strong class="cp-emphasis">Complete Backup of your Site and Database</strong> before using this tool<strong class="cp-emphasis"> At Your Own Risk!</strong>',
 							'switch-to-classicpress'
 						); ?>
 					</p>

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -494,7 +494,7 @@ if (strpos($cp_version, 'migration')) {
 	$default_theme = "<a href='$theme_url'>$theme_name</a>";
 	$theme_info = "<strong>The safest way of switching to ClassicPress is to install and activate the fully compatible theme <em>$default_theme</em>.</strong>
 	<br>You can <strong class='cp-emphasis'>Continue at Your Own Risk</strong> with your current theme, but you may experience issues if the theme is not compatible with ClassicPress.";	
-/* THEME CHECKS DISABLED - WARN INSTEAD
+/* THEME CHECKS DISABLED / WARN ONLY - (I kept this code for referance but a rework could be done to remove it and more code that is no longer needed)
 	$fse_info = "<br>Block and Full Screen Editor themes may work in ClassicPress, but you will have to test the theme(s) you plan to use and verify that they work correctly.";
 	if (
 		in_array( $theme->stylesheet, (array) $cp_api_parameters['themes'] ) ||
@@ -560,6 +560,7 @@ if (strpos($cp_version, 'migration')) {
 	$plugin_info = "It looks like you have active plugins, you should test the plugins you plan to use after migration and verify they work correctly.";
 
 	// Start by checking if plugins have declared they require WordPress 5.0 or higher
+	// CHANGED TO CHECK FOR WP 1.0 OR HIGHER / ALL PLUGINS
 	foreach ( $plugins as $plugin ) {
 		if ( in_array( $plugin, $cp_api_parameters['plugins'] ) ) {
 			continue;
@@ -567,9 +568,9 @@ if (strpos($cp_version, 'migration')) {
 //		echo $plugin;
 		$migchk = explode ( '/', $plugin );
 		if ( $migchk[1] === 'switch-to-classicpress.php' ) {
-			continue; // Skip this plugin
+			continue; // skip the Switch to ClassicPress plugin
 		}
-  // Get the plugin data
+  		// Get the plugin data
 		$plugin_data = get_file_data( WP_PLUGIN_DIR . '/' . $plugin, $plugin_headers );
 		$plugin_name = $plugin_data['Name'];
 		if ( version_compare( $plugin_data['RequiresWP'], '1.0' ) >= 0 ) {
@@ -646,9 +647,9 @@ if (strpos($cp_version, 'migration')) {
 			<br>You can <strong class='cp-emphasis'>Continue at Your Own Risk</strong> with active plugins, but you may experience issues if any plugins are not compatible with ClassicPress.",
 			'switch-to-classicpress'
 		);
-		//echo "<br>\n";
-		// translators: List of conflicting plugin names - DISPLAY DISABLED BELOW
+		// translators: List of conflicting plugin names - UNCOMMENT TO DISPLAY
 /*	
+		echo "<br>\n";
 		printf( wp_kses_post(
 			'<strong>%s<strong>',
 			'switch-to-classicpress'
@@ -785,7 +786,7 @@ if (strpos($cp_version, 'migration')) {
 			// translators: modified core file name
 			echo esc_html( sprintf( ' - %s', $file ) ) . "<br>\n";
 		}
-/*
+/*		OLD METHOD SENT TO CONSOLE - CAN BE REMOVED
 		echo wp_kses_post(
 			'If you have JavaScript enabled, you can see a list of modified files <strong>in your browser console</strong>.',
 			'switch-to-classicpress'
@@ -1062,7 +1063,7 @@ function classicpress_show_advanced_migration_controls( $ok = true ) {
 					</p>
 					<p>
 						<?php echo wp_kses_post(
-							'Please, make a <strong class="cp-emphasis">Complete Backup of your Site and Database</strong> before using this tool<strong class="cp-emphasis"> At Your Own Risk!</strong>',
+							'Please, make a <strong class="cp-emphasis">Complete Backup of your Site Files and Database</strong> before using this tool<strong class="cp-emphasis"> At Your Own Risk!</strong>',
 							'switch-to-classicpress'
 						); ?>
 					</p>

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -648,12 +648,12 @@ if (strpos($cp_version, 'migration')) {
 		);
 		//echo "<br>\n";
 		// translators: List of conflicting plugin names - DISPLAY DISABLED BELOW
-//	
+/*	
 		printf( wp_kses_post(
 			'<strong>%s<strong>',
 			'switch-to-classicpress'
 		), esc_html( implode( ', ', $undeclared_compatibility_plugins ) ) );
-//
+*/
 		echo "</p></td></tr>\n";
 		} else {
 		$preflight_checks['plugins'] = true;

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -467,25 +467,14 @@ if (strpos($cp_version, 'migration')) {
 		echo "<p>\n";
 		echo wp_kses_post( $wp_version_check_intro_message );
 	}
-	/* translators: current WordPress version
-	printf( wp_kses_post(
-		'You are running WordPress version <strong>%s</strong>.',
-		'switch-to-classicpress'
-	), esc_html( $wp_version ) );
-	*/
+
 	if ( substr( $wp_version, 0, 1 ) >= '5' && $preflight_checks['wp_version'] ) {
 		//echo "<br>\n";
 		esc_html_e(
 			'Content edited with the WordPress Block Editor may not be fully compatible with ClassicPress.',
 			'switch-to-classicpress'
 		);
-/* THIS NEXT LINE IS DISABLED - I THINK THE ABOVE IS ENOUGH
-		echo "<br>\n";
-		esc_html_e(
-			'After the migration, we recommend reviewing each recently edited post or page and restoring to an earlier revision if needed.',
-			'switch-to-classicpress'
-		);
-*/
+
 	}
 	echo "\n</p>\n";
 	// TODO: Add instructions if WP too old.
@@ -498,41 +487,7 @@ if (strpos($cp_version, 'migration')) {
 	$default_theme = "<a href='$theme_url'>$theme_name</a>";
 	$theme_info = "<strong>The safest way of switching to ClassicPress is to install and activate the fully compatible theme <em>$default_theme</em>.</strong>
 	<br>You can <strong class='cp-emphasis'>Continue at Your Own Risk</strong> with your current theme, but you may experience issues if the theme is not compatible with ClassicPress.";	
-/* THEME CHECKS DISABLED / WARN ONLY (Since v1.6) - (I kept this code for referance but a rework could be done to remove it and more code that is no longer needed)
-	$fse_info = "<br>Block and Full Screen Editor themes may work in ClassicPress, but you will have to test the theme(s) you plan to use and verify that they work correctly.";
-	if (
-		in_array( $theme->stylesheet, (array) $cp_api_parameters['themes'] ) ||
-		( is_child_theme() && in_array( $theme->parent()->stylesheet, (array) $cp_api_parameters['themes'] ) )
-	) {
-		$preflight_checks['theme'] = false;
-		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_fail) . "</td>\n<td>\n<p>\n";
-		// translators: active theme name
-		printf( wp_kses_post(
-			'It looks like you are using the <strong>%1$s</strong> theme. Unfortunately, %1$s is known to be incompatible with ClassicPress.%2$s',
-			'switch-to-classicpress'
-		), esc_html( $theme->name ), wp_kses_post( $fse_info ) );
-		echo "<br>\n";
-		echo wp_kses_post(
-			$theme_info,
-			'switch-to-classicpress'
-		);
-//  } elseif ( version_compare( $theme->get( 'RequiresWP' ), '5.0' ) >= 0 ) {
-	} elseif ( in_array( 'full-site-editing', $theme->tags ) ) {
-		$preflight_checks['theme'] = false;
-		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_fail) . "</td>\n<td>\n<p>\n";
-		printf( wp_kses_post(
-			// translators: active theme name
-			'It looks like you are using the <strong>%1$s</strong> theme. Unfortunately, %1$s is probably using FSE functions and may not be compatible with ClassicPress.%2$s',
-			'switch-to-classicpress'
-//      ), $theme->name, $theme->get( 'RequiresWP' ) );
-		), esc_html( $theme->name ), wp_kses_post( $fse_info ) );
-		echo "<br>\n";
-		echo wp_kses_post(
-			$theme_info,
-			'switch-to-classicpress'
-		);
-	} elseif ( $theme->name === $theme_name ) {
-*/
+// THEME CHECKS DISABLED / WARN ONLY (Since v1.6)
 	if ( $theme->name === $theme_name ) {
 		$preflight_checks['theme'] = true;
 		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_pass) . "</td>\n<td>\n<p>\n";
@@ -563,86 +518,7 @@ if (strpos($cp_version, 'migration')) {
 	$undeclared_compatibility_plugins = array();
 	$plugin_info = "It looks like you have active plugins, you should test the plugins you plan to use after migration and verify they work correctly.";
 
-	// Start by checking if plugins have declared they require WordPress 5.0 or higher
-	// CHANGED TO CHECK FOR WP 1.0 OR HIGHER / ALL PLUGINS
-	// DISABLED (Since v1.6)
-	/*
-	foreach ( $plugins as $plugin ) {
-		if ( in_array( $plugin, $cp_api_parameters['plugins'] ) ) {
-			continue;
-		}
-		$migchk = explode ( '/', $plugin );
-		if ( ( isset($migchk[1]) ? $migchk[1] : '' ) === 'switch-to-classicpress.php' ) {
-			continue; // skip the Switch to ClassicPress plugin
-		}
-  		// Get the plugin data
-		$plugin_data = get_file_data( WP_PLUGIN_DIR . '/' . $plugin, $plugin_headers );
-		$plugin_name = $plugin_data['Name'];
-		if ( version_compare( $plugin_data['RequiresWP'], '1.0' ) >= 0 ) {
-			$undeclared_compatibility_plugins[ $plugin ] = $plugin_name;
-		} else {
-			$plugin_files = get_plugin_files( $plugin );
-			$readmes = array_filter( $plugin_files, function ( $files ) {
-				return ( stripos( $files, 'readme') !== false );
-			} );
-			foreach( $readmes as $readme ) {
-				if ( empty( $readme ) ) {
-					continue;
-				}
-				$readme_data = get_file_data( WP_PLUGIN_DIR . '/' . $readme, $plugin_headers );
-				if ( version_compare( $readme_data['RequiresWP'], '1.0' ) >= 0 ) {
-					$undeclared_compatibility_plugins[ $plugin ] = $plugin_name;
-					continue;
-				}
-			}
-		}
-		if (
-			empty( $plugin_data['RequiresWP'] ) &&
-			( empty( $readmes ) || empty( $readme_data['RequiresWP'] ) ) &&
-			false === array_key_exists( $plugin, $declared_incompatible_plugins )
-		) {
-			$undeclared_compatibility_plugins[ $plugin ] = $plugin_name;
-		}
-	}
-	*/
-
-	// Compare active plugins with API response of known conflicting plugins
-	$cp_api_parameters['plugins'] = []; // DISABLES THIS CHECK (Since v1.6)
-	if (
-		$plugins !== array_diff( $plugins, $cp_api_parameters['plugins'] ) ||
-		! empty( $declared_incompatible_plugins )
-	) {
-		$preflight_checks['plugins'] = false;
-		$conflicting_plugins = array_intersect( $cp_api_parameters['plugins'], $plugins );
-		$conflicting_plugin_names = array();
-		foreach( $conflicting_plugins as $conflicting_plugin ) {
-			$conflicting_plugin_data = get_plugin_data( WP_CONTENT_DIR . '/plugins/' . $conflicting_plugin );
-			$conflicting_plugin_names[] = $conflicting_plugin_data['Name'];
-		}
-		if ( ! empty( $declared_incompatible_plugins ) ) {
-			foreach( $declared_incompatible_plugins as $slug => $name ) {
-				$conflicting_plugin_names[] = $name;
-			}
-		}
-		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_fail) . "</td>\n<td>\n<p>\n";
-		esc_html_e(
-			'We have detected one or more known incompatible plugins that prevent migrating your site to ClassicPress.',
-			'switch-to-classicpress'
-		);
-		echo "<br>\n";
-		esc_html_e(
-			'Please deactivate the following plugins if you wish to continue migrating your site to ClassicPress:',
-			'switch-to-classicpress'
-		);
-		echo "<br>\n";
-		// translators: List of conflicting plugin names
-		printf( wp_kses_post(
-			'<strong>%s<strong>',
-			'switch-to-classicpress'
-		), esc_html( implode( ', ', $conflicting_plugin_names ) ) );
-		// } elseif ( ! empty( $undeclared_compatibility_plugins ) ) {
-		// CHANGED TO AVOID LOOPING TROUGH PLUGINS ABOVE (Since v.1.6)
-		} elseif ( count($plugins) > 1 ) {
+		if ( count($plugins) > 1 ) {
 		$preflight_checks['plugins'] = true;
 		echo "<tr>\n<td>" . wp_kses_post($icon_preflight_warn) . "</td>\n<td>\n<p>\n";
 		echo wp_kses_post(
@@ -655,15 +531,6 @@ if (strpos($cp_version, 'migration')) {
 			<br>You can <strong class='cp-emphasis'>Continue at Your Own Risk</strong> with active plugins, but you may experience issues if any plugins are not compatible with ClassicPress.",
 			'switch-to-classicpress'
 		);
-		// translators: List of conflicting plugin names
-		// UNCOMMENT TO DISPLAY (Since v1.6)
-/*	
-		echo "<br>\n";
-		printf( wp_kses_post(
-			'<strong>%s<strong>',
-			'switch-to-classicpress'
-		), esc_html( implode( ', ', $undeclared_compatibility_plugins ) ) );
-*/
 		echo "</p></td></tr>\n";
 		} else {
 		$preflight_checks['plugins'] = true;
@@ -795,15 +662,7 @@ if (strpos($cp_version, 'migration')) {
 			// translators: modified core file name
 			echo esc_html( sprintf( ' - %s', $file ) ) . "<br>\n";
 		}
-/*		OLD METHOD SENT TO CONSOLE - CAN BE REMOVED
-		echo wp_kses_post(
-			'If you have JavaScript enabled, you can see a list of modified files <strong>in your browser console</strong>.',
-			'switch-to-classicpress'
-		);
-		echo "\n<script>console.log( 'modified core files:', ";
-		echo wp_json_encode( $modified_files );
-		echo ' );</script>';
-*/
+
 	}
 	echo "\n</p>\n";
 	echo "</td></tr>\n";

--- a/switch-to-classicpress.php
+++ b/switch-to-classicpress.php
@@ -3,8 +3,8 @@
  * Plugin Name:       Switch to ClassicPress
  * Plugin URI:        https://github.com/ClassicPress/ClassicPress-Migration-Plugin
  * Description:       Switch your WordPress installation to ClassicPress.
- * Version:           1.5.2
- * Author:            ClassicPress
+ * Version:           1.5.3
+ * Author:            ClassicPress Team
  * Author URI:        https://www.classicpress.net
  * License:           GPLv2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.txt
@@ -13,7 +13,7 @@
  * Requires CP:       1.7
  * Requires PHP:      7.4
  * Requires at least: 4.9
- * Tested up to:      6.7
+ * Tested up to:      6.8
  * Network:           true
  * @package ClassicPress
  */

--- a/switch-to-classicpress.php
+++ b/switch-to-classicpress.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Switch to ClassicPress
  * Plugin URI:        https://github.com/ClassicPress/ClassicPress-Migration-Plugin
  * Description:       Switch your WordPress installation to ClassicPress.
- * Version:           1.5.3
+ * Version:           1.6.0
  * Author:            ClassicPress Team
  * Author URI:        https://www.classicpress.net
  * License:           GPLv2 or later


### PR DESCRIPTION
- Change Plugin and Theme Checks to explain safest method, but only warn if not followed
- Change Core File check to show any modified files on the page rather than in the console
- Display override function info for unsupported WP versions when applicable
- Correct links and update wording as needed
- Bump version to 1.5.3