### PR TITLE
Translation related fixes

### DIFF
--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -283,7 +283,7 @@ function classicpress_ignore_wp_version_checkbox_callback() {
 		'</a>'
 	);
 }
- 
+
 add_action( 'admin_init', 'classicpress_ignore_wp_version_settings_init' );
 
 /**
@@ -368,7 +368,7 @@ function classicpress_check_can_migrate() {
 				); ?>
 			</p>
 			<p>
-				<?php echo esc_html_e(
+				<?php esc_html_e(
 					'In order to switch to ClassicPress, you\'ll need to move to a self-hosted WordPress site first.',
 					'switch-to-classicpress'
 				); ?>
@@ -771,7 +771,7 @@ function classicpress_show_migration_controls() {
 	<p class="cp-migration-info">
 		<?php echo wp_kses_post(
 			'<strong class="cp-emphasis">' . __( 'Please make a Complete Backup of your Site Files and Database before you continue!', 'switch-to-classicpress' ) . '</strong>'
-		); ?>	
+		); ?>
 	</p>
 	<p class="cp-migration-info">
 		<?php echo wp_kses_post(
@@ -989,7 +989,7 @@ function classicpress_show_advanced_migration_controls( $ok = true ) {
 				</th>
 				<td>
 					<p>
-						<?php echo esc_html_e(
+						<?php esc_html_e(
 							'If all requirements for your custom version have been met, then migration should complete.',
 							'switch-to-classicpress'
 						); ?>

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -368,8 +368,8 @@ function classicpress_check_can_migrate() {
 				); ?>
 			</p>
 			<p>
-				<?php echo wp_kses_post(
-					__( 'In order to switch to ClassicPress, you\'ll need to <a href="https://move.wordpress.com/">move to a self-hosted WordPress site</a> first.',
+				<?php echo esc_html_e(
+					__( 'In order to switch to ClassicPress, you\'ll need to move to a self-hosted WordPress site first.',
 					'switch-to-classicpress' )
 				); ?>
 			</p>
@@ -989,14 +989,20 @@ function classicpress_show_advanced_migration_controls( $ok = true ) {
 				</th>
 				<td>
 					<p>
-						<?php echo wp_kses_post(
-							__( 'If all requirements for your custom version have been met, then migration should complete.</p><p>That does not mean it will work in every case and<strong class="cp-emphasis"> Older Versions may have Password or Security Issues!</strong></p>',
+						<?php echo esc_html_e(
+							__( 'If all requirements for your custom version have been met, then migration should complete.',
 							'switch-to-classicpress' )
 						); ?>
 					</p>
 					<p>
 						<?php echo wp_kses_post(
-							__( 'Please, make a <strong class="cp-emphasis">Complete Backup of your Site Files and Database</strong> before using this tool<strong class="cp-emphasis"> At Your Own Risk!</strong>',
+							__( 'That does not mean it will work in every case and <strong class="cp-emphasis">Older Versions may have Password or Security Issues!</strong>',
+							'switch-to-classicpress' )
+						); ?>
+					</p>
+					<p>
+						<?php echo wp_kses_post(
+							__( 'Please, make a <strong class="cp-emphasis">Complete Backup of your Site Files and Database</strong> before using this tool <strong class="cp-emphasis">At Your Own Risk!</strong>',
 							'switch-to-classicpress' )
 						); ?>
 					</p>

--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -369,8 +369,8 @@ function classicpress_check_can_migrate() {
 			</p>
 			<p>
 				<?php echo esc_html_e(
-					__( 'In order to switch to ClassicPress, you\'ll need to move to a self-hosted WordPress site first.',
-					'switch-to-classicpress' )
+					'In order to switch to ClassicPress, you\'ll need to move to a self-hosted WordPress site first.',
+					'switch-to-classicpress'
 				); ?>
 			</p>
 		</div>
@@ -990,8 +990,8 @@ function classicpress_show_advanced_migration_controls( $ok = true ) {
 				<td>
 					<p>
 						<?php echo esc_html_e(
-							__( 'If all requirements for your custom version have been met, then migration should complete.',
-							'switch-to-classicpress' )
+							'If all requirements for your custom version have been met, then migration should complete.',
+							'switch-to-classicpress'
 						); ?>
 					</p>
 					<p>


### PR DESCRIPTION
This PR fixes a few strings after checking the POT file of #123.
Re the removal of the link to WP com: user is promted to switch to self-hosted site, but the string links to a page with info about moving to WP com. Makes no sense.