### PR TITLE
Change some options and user meta on migration

### DIFF
--- a/lib/update.php
+++ b/lib/update.php
@@ -376,9 +376,14 @@ function classicpress_migrate_settings() {
 		update_option( 'blogdescription', 'Just another ClassicPress site.' );
 	}
 
-	// Update color scheme
-	$blogusers = get_users();
-	foreach ( $blogusers as $user ) {
-		update_user_meta( $user->ID, 'admin_color', 'fresh', 'modern' );
+	$wp_version_was = get_option( 'classicpress_restore_wp_version', '0.0' );
+
+	// Migration from WP >= 7
+	if ( version_compare ( $wp_version_was, '7.0', 'ge' ) ) {
+		// Update color scheme
+		$blogusers = get_users();
+		foreach ( $blogusers as $user ) {
+			update_user_meta( $user->ID, 'admin_color', 'fresh', 'modern' );
+		}
 	}
 }

--- a/lib/update.php
+++ b/lib/update.php
@@ -379,8 +379,6 @@ function classicpress_migrate_settings() {
 	// Update color scheme
 	$blogusers = get_users();
 	foreach ( $blogusers as $user ) {
-		$user_id     = $user->ID;
-		$admin_color = get_user_meta( $user_id, 'admin_color' );
-		update_user_meta( $user_id, 'admin_color', 'fresh', 'modern' );
+		update_user_meta( $user->ID, 'admin_color', 'fresh', 'modern' );
 	}
 }

--- a/lib/update.php
+++ b/lib/update.php
@@ -365,7 +365,7 @@ add_action( 'admin_head-update-core.php', 'classicpress_clear_stale_data' );
  * Migrate settings after migration:
  *
  *  - Change default Blog Info
- *  - Change color cheme
+ *  - Change color scheme
  *
  * @since 1.7.0
  */
@@ -374,7 +374,6 @@ function classicpress_migrate_settings() {
 	$blogdescription = get_option( 'blogdescription' );
 	if ( $blogdescription === 'Just another WordPress site.' ) {
 		update_option( 'blogdescription', 'Just another ClassicPress site.' );
-		trigger_error("updated bd");
 	}
 
 	// Update color scheme

--- a/lib/update.php
+++ b/lib/update.php
@@ -353,6 +353,35 @@ function classicpress_clear_stale_data() {
 
 	// Remove the flag indicating that a migration was recently performed.
 	delete_site_transient( 'classicpress_migrated' );
+
+	// Change needed settings
+	classicpress_migrate_settings();
+
 }
 add_action( 'admin_head-about.php', 'classicpress_clear_stale_data' );
 add_action( 'admin_head-update-core.php', 'classicpress_clear_stale_data' );
+
+/**
+ * Migrate settings after migration:
+ *
+ *  - Change default Blog Info
+ *  - Change color cheme
+ *
+ * @since 1.7.0
+ */
+function classicpress_migrate_settings() {
+	// Update Blog Description
+	$blogdescription = get_option( 'blogdescription' );
+	if ( $blogdescription === 'Just another WordPress site.' ) {
+		update_option( 'blogdescription', 'Just another ClassicPress site.' );
+		trigger_error("updated bd");
+	}
+
+	// Update color scheme
+	$blogusers = get_users();
+	foreach ( $blogusers as $user ) {
+		$user_id     = $user->ID;
+		$admin_color = get_user_meta( $user_id, 'admin_color' );
+		update_user_meta( $user_id, 'admin_color', 'fresh', 'modern' );
+	}
+}


### PR DESCRIPTION
As suggested by [ranwest](https://forums.classicpress.net/u/ranwest) the migration plugin changes the default Blog Info from `Just another WordPress site.` to `Just another ClassicPress site.`
Closes #129.

As a new function is introduced to handle post-migration changes, the new function also changes the newly introduced (and forced by WP) `modern` color scheme to our default `fresh`.