### PR TITLE
Hardcode WP Latest version in Advanced Version Control

### DIFF
--- a/lib/admin-page.php
+++ b/lib/admin-page.php
@@ -1057,7 +1057,7 @@ function classicpress_show_advanced_migration_controls( $ok = true ) {
 					</optgroup>
 					<optgroup label="<?php esc_html_e( 'WordPress Builds', 'switch-to-classicpress' ); ?>">
 <?php if ($wp_version !== $cp_api_parameters['wordpress']['max']) { ?>
-						<option value="<?php echo esc_url($cp_api_parameters['links']['WordPress Latest']); ?>">WordPress v<?php echo esc_html($cp_api_parameters['wordpress']['max']); ?></option>
+						<option value="https://wordpress.org/latest.zip">WordPress Latest</option>
 <?php
 	}
 	if (!$is_wp && $wp_v6 === $wp_version) { $wp_check = "0.0.0"; } else { $wp_check = $wp_version; }


### PR DESCRIPTION
If the migration endpoint of ClassicPress's API report `$cp_api_parameters['wordpress']['max']` lower than the current WP version the select show a wrong label.

This PR hardcode the value.

Closes #132.

### Before

<img width="439" height="144" alt="image" src="https://github.com/user-attachments/assets/c05fe9e9-4c49-45ee-8b4f-60478206f3cf" />


### After

<img width="429" height="139" alt="image" src="https://github.com/user-attachments/assets/f51aef41-3ce3-424e-9845-c5bdf121e036" />


